### PR TITLE
Replace body-parser with express inbuilt functions

### DIFF
--- a/server/src/index.js
+++ b/server/src/index.js
@@ -1,7 +1,6 @@
 // main server file
 
 require("dotenv").config();
-const bodyParser = require("body-parser");
 const cors = require("cors");
 const http = require("http");
 const morgan = require("morgan");
@@ -27,9 +26,8 @@ app.use(helmet());
 app.options("*", cors());
 app.use(cors({ origin: "http://localhost:5000" }));
 
-// body-parser
-app.use(bodyParser.urlencoded({ extended: true }));
-app.use(bodyParser.json());
+app.use(express.urlencoded());
+app.use(express.json());
 
 // database connection
 mongoose.connect(


### PR DESCRIPTION
## Related Issue

- Since express versions 4.16 and above, express' body-parser is included in the default express package and there is no need to install additional body-parser dependencies to the application.

Closes: #89 

#### Describe the changes you've made

Replaced the use of body-parser's urlencoded and JSON parser with express's inbuilt functions.

## Checklist:

<!--
Example how to mark a checkbox:-
- [x] My code follows the code style of this project.
-->

- [x] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.

