### PR TITLE
edit answer (backend)

### DIFF
--- a/server/src/controllers/answers.controller.js
+++ b/server/src/controllers/answers.controller.js
@@ -41,7 +41,37 @@ const deleteAnswer = async(req, res) => {
     }
 }
 
+const editAnswer = async(req, res) =>{
+    try{
+        const answer = await Answers.findOne({_id: req.params.id, createdBy: req.user._id})
+        const edits = Object.keys(req.body)
+        const permittededits = ['tags', 'answerText'] //allowing a user to update only these fields
+        const isValid = edits.every((edit)=>{
+            return permittededits.includes(edit)
+        })
+        if(!isValid){
+            res.status(400).send({error: 'Invalid edits!'})
+        }
+        try{    
+            edits.forEach(edit => {
+                answer[edit] = req.body[edit]
+            })
+            
+            await answer.save()
+            return res.status(200).json({message: "answer updated!"})
+    
+        }
+        catch(e){
+            res.status(400).send({message: "something went wrong!"})
+        }
+    }
+    catch(e){
+        res.status(400).send({message: "something went wrong!"})
+    }
+}
+
 module.exports = answerController = {
     createAnswers,
-    deleteAnswer
+    deleteAnswer,
+    editAnswer
 };

--- a/server/src/routes/answers.routes.js
+++ b/server/src/routes/answers.routes.js
@@ -13,5 +13,6 @@ router.post(
     answerController.createAnswers
 );
 router.delete('/deleteAnswer/:id', requireSignin, userMiddleWare, answerController.deleteAnswer)
+router.patch('/editAnswer/:id', requireSignin, userMiddleWare, answerController.editAnswer)
 
 module.exports = router;


### PR DESCRIPTION
## Related Issuse

- A user was not able to edit the answer once he/she had posted it, editAnswer route enables the user to do so using the answer 
  _id

Closes: #225 

#### - added a patch request which enables the user to pass the id of a particular answer (as a parameter) and modify the existing answer (modification of 2 fields is permitted: 1. answerText 2. tags).  The user can update an answer only if it was created by him/her


## Checklist:

<!--
Example how to mark a checkbox:-
- [x] My code follows the code style of this project.
-->

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.(Specially for Backend)
- [x] My changes generate no new warnings.

No changes in the documentation are required corresponding to the changes that I have made

## Screenshots

|        Original         |          Updated           |
| :---------------------: | :------------------------: |
| **no edit answer route** | <b> ![Screenshot (376)](https://user-images.githubusercontent.com/61057219/115501905-aeb53180-a291-11eb-9ebd-f67f5a7aa7b8.png) </b> |


